### PR TITLE
wp_deregister_script is causing some plugins not to work

### DIFF
--- a/header.php
+++ b/header.php
@@ -38,7 +38,8 @@
 
 <!-- Load scripts quick smart -->
 
-	<?php wp_deregister_script('jquery');wp_head(); ?>
+ 	<?php //wp_deregister_script('jquery');wp_head(); ?>
+	<?php wp_head(); ?>
 </head>
 
 <body <?php body_class(); ?> id="top">


### PR DESCRIPTION
I had trouble recently with the Meta Slider plugin on a Multisite build. I found out that somehow the *wp_deregister_script was the cause. Not sure if there is another way to write this. But I think it would be better to use the default wp_head for now.